### PR TITLE
Jaunter changes, golem ship has area and tracking beacon, equipment

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -1,34 +1,35 @@
 "a" = (/turf/template_noop,/area/template_noop)
-"b" = (/turf/closed/wall/shuttle/smooth/nodiagonal{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"c" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"d" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"e" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"f" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"g" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"h" = (/obj/structure/shuttle/engine/heater{icon_state = "heater"; dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered)
-"i" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered)
-"j" = (/obj/machinery/door/airlock/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"k" = (/obj/machinery/computer/arcade/battle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"l" = (/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"m" = (/obj/effect/mob_spawn/human/golem/adamantine,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"n" = (/obj/machinery/mineral/equipment_vendor/golem,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"o" = (/obj/item/weapon/resonator,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"p" = (/obj/machinery/mineral/ore_redemption,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"q" = (/obj/structure/statue/gold/rd,/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"r" = (/obj/machinery/computer/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"s" = (/obj/structure/extinguisher_cabinet{pixel_y = 30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"t" = (/obj/structure/table/wood,/obj/item/weapon/bedsheet/rd{desc = "Majestic."; layer = 3; name = "Royal Cape of the Liberator"; pixel_x = 5; pixel_y = 9},/obj/item/weapon/book/manual/research_and_development{name = "Sacred Text of the Liberator"; pixel_x = -4; pixel_y = 3},/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"u" = (/obj/item/weapon/resonator/upgraded,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"v" = (/obj/machinery/autolathe,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"w" = (/obj/structure/table/wood,/obj/machinery/reagentgrinder,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"x" = (/obj/machinery/computer/arcade/orion_trail,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"y" = (/obj/structure/extinguisher_cabinet{pixel_y = -30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"z" = (/obj/structure/table/wood,/obj/item/weapon/surgical_drapes{pixel_x = 15},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"A" = (/obj/item/weapon/storage/firstaid/fire,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"B" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/areaeditor/blueprints{desc = "Use to build new structures in the wastes."; name = "land claim"},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"C" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/weapon/disk/design_disk/golem_shell,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"D" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"E" = (/obj/structure/ore_box,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"b" = (/turf/closed/wall/shuttle/smooth/nodiagonal{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"c" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"d" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"e" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"f" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"g" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"h" = (/obj/structure/shuttle/engine/heater{icon_state = "heater"; dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/golem_ship)
+"i" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/golem_ship)
+"j" = (/obj/machinery/door/airlock/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"k" = (/obj/machinery/computer/arcade/battle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"l" = (/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"m" = (/obj/effect/mob_spawn/human/golem/adamantine,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"n" = (/obj/machinery/mineral/equipment_vendor/golem,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"o" = (/obj/item/weapon/resonator,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"p" = (/obj/machinery/mineral/ore_redemption,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"q" = (/obj/structure/statue/gold/rd,/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"r" = (/obj/machinery/computer/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"s" = (/obj/machinery/bluespace_beacon,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"t" = (/obj/structure/extinguisher_cabinet{pixel_y = 30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"u" = (/obj/structure/table/wood,/obj/item/weapon/bedsheet/rd{desc = "Majestic."; layer = 3; name = "Royal Cape of the Liberator"; pixel_x = 5; pixel_y = 9},/obj/item/weapon/book/manual/research_and_development{name = "Sacred Text of the Liberator"; pixel_x = -4; pixel_y = 3},/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"v" = (/obj/item/weapon/resonator/upgraded,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"w" = (/obj/machinery/autolathe,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"x" = (/obj/structure/table/wood,/obj/machinery/reagentgrinder,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"y" = (/obj/machinery/computer/arcade/orion_trail,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"z" = (/obj/structure/extinguisher_cabinet{pixel_y = -30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"A" = (/obj/structure/table/wood,/obj/item/weapon/surgical_drapes{pixel_x = 15},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"B" = (/obj/item/weapon/storage/firstaid/fire,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"C" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/areaeditor/blueprints{desc = "Use to build new structures in the wastes."; name = "land claim"},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"D" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/weapon/disk/design_disk/golem_shell,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"E" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"F" = (/obj/structure/ore_box,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
@@ -40,14 +41,14 @@ aabbbbjjbbbbjjbbbbbb
 aabkllllmmbllllllnhi
 aabllllloojlllllllhi
 bbbjjbbbbbblllllpbbb
-bqrllllllljlllllljsj
-btlllllllljlllllljlj
-bbbjjbbbbbblllluvbbb
-aabllllloojllllllwhi
-aabxllllmmbyllzABChi
+bqrllllllljlslllljtj
+bulllllllljlllllljlj
+bbbjjbbbbbbllllvwbbb
+aabllllloojllllllxhi
+aabyllllmmbzllABCDhi
 aabbbbjjbbbbjjbbbbbb
-aaaaabfffffffffffDhi
-aaaaabEEEEEEEefffDhi
+aaaaabfffffffffffEhi
+aaaaabFFFFFFFefffEhi
 aaaaabbbbbbbbbbbbbbb
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -572,3 +572,6 @@ obj/item/proc/item_action_slot_check(slot, mob/user)
 
 /obj/item/proc/is_sharp()
 	return sharpness
+
+/obj/item/proc/chasm_react(mob/user)
+	return FALSE

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -293,8 +293,8 @@
 		new /datum/data/mining_equipment("Explorer Belt",		/obj/item/weapon/storage/belt/mining,									500),
 		new /datum/data/mining_equipment("Survival Medipen",	/obj/item/weapon/reagent_containers/hypospray/medipen/survival,			500),
 		new /datum/data/mining_equipment("Brute First-Aid Kit",	/obj/item/weapon/storage/firstaid/brute,						   		600),
-		new /datum/data/mining_equipment("Jaunter",             /obj/item/device/wormhole_jaunter,                                 		600),
 		new /datum/data/mining_equipment("Tracking Implant Kit",/obj/item/weapon/storage/box/minertracker,                              600),
+		new /datum/data/mining_equipment("Wormhole Lifebelt",   /obj/item/device/wormhole_lifebelt,										750),
 		new /datum/data/mining_equipment("Kinetic Accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,               	   		750),
 		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                    	   		800),
 		new /datum/data/mining_equipment("Lazarus Injector",    /obj/item/weapon/lazarus_injector,                                		1000),
@@ -422,7 +422,7 @@
 	return ..()
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/weapon/mining_voucher/voucher, mob/redeemer)
-	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in list("Survival Capsule and Explorer Belt", "Resonator", "Mining Drone", "Advanced Scanner")
+	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in list("Survival Capsule and Explorer Belt", "Resonator", "Mining Drone", "Advanced Scanner", "Wormhole Lifebelt")
 	if(!selection || !Adjacent(redeemer) || qdeleted(voucher) || voucher.loc != redeemer)
 		return
 	switch(selection)
@@ -436,6 +436,8 @@
 			new /obj/item/weapon/weldingtool/hugetank(src.loc)
 		if("Advanced Scanner")
 			new /obj/item/device/t_scanner/adv_mining_scanner(src.loc)
+		if("Wormhole Lifebelt")
+			new /obj/item/device/wormhole_lifebelt(src.loc)
 
 	feedback_add_details("mining_voucher_redeemed", selection)
 	qdel(voucher)
@@ -483,9 +485,17 @@
 
 /**********************Jaunter**********************/
 
-/obj/item/device/wormhole_jaunter
-	name = "wormhole jaunter"
-	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to blue space for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThanks to modifications provided by the Free Golems, this jaunter can be worn on the belt to provide protection from chasms."
+/obj/item/device/wormhole_lifebelt
+	name = "wormhole lifebelt"
+	desc = "A single use safety device harnessing outdated wormhole \
+		technology. It bares the hallmarks of the work of the Free Golems, as \
+		Nanotrasen has turned its eyes to bluespace for more accurate \
+		teleportation.\n\
+		It's designed to be worn around the waist, monitoring lifesigns and \
+		acceleration. In the event of a medical emergency, or a fall severe \
+		enough to qualify as fatal, it activates.\n\
+		The wormholes it creates are unpleasant to travel through though, to \
+		say the least."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Jaunter"
 	item_state = "electronic"
@@ -496,38 +506,107 @@
 	origin_tech = "bluespace=2"
 	slot_flags = SLOT_BELT
 
-/obj/item/device/wormhole_jaunter/attack_self(mob/user)
+	var/obj/item/device/radio/belt_radio
+	var/radio_key = /obj/item/device/encryptionkey/headset_cargo
+	var/radio_channel = "Supply"
+
+	var/ticks_in_crit = 0
+	var/threshold = 2
+
+/obj/item/device/wormhole_lifebelt/New()
+	. = ..()
+	SSobj.processing += src
+
+	belt_radio = new /obj/item/device/radio(src)
+	belt_radio.keyslot = new radio_key
+	belt_radio.subspace_transmission = 1
+	belt_radio.canhear_range = 0
+	belt_radio.recalculateChannels()
+
+
+/obj/item/device/wormhole_lifebelt/Destroy()
+	SSobj.processing -= src
+	qdel(belt_radio)
+	. = ..()
+
+/obj/item/device/wormhole_lifebelt/process()
+	var/mob/living/carbon/human/user
+	if(istype(loc, /mob/living/carbon/human))
+		user = loc
+	else
+		return
+
+	if(user.get_item_by_slot(slot_belt) != src)
+		return
+
+	if(user.InCritical())
+		if(ticks_in_crit == 0)
+			user << "<span class='notice'>You feel [src] growing warm and vibrating.</span>"
+		ticks_in_crit += 1
+		if(ticks_in_crit >= threshold)
+			feedback_add_details("jaunter", "M") // medical activation
+			belt_radio.talk_into(src, "Medical activation for [user] but yeah, go do whatever.", radio_channel)
+			activate(user)
+	else
+		ticks_in_crit = 0
+
+/obj/item/device/wormhole_lifebelt/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
 	feedback_add_details("jaunter", "U") // user activated
 	activate(user)
 
-/obj/item/device/wormhole_jaunter/proc/turf_check(mob/user)
+/obj/item/device/wormhole_lifebelt/proc/turf_check(mob/user)
 	var/turf/device_turf = get_turf(user)
 	if(!device_turf||device_turf.z==2||device_turf.z>=7)
 		user << "<span class='notice'>You're having difficulties getting the [src.name] to work.</span>"
 		return FALSE
 	return TRUE
 
-/obj/item/device/wormhole_jaunter/proc/activate(mob/user)
+/obj/item/device/wormhole_lifebelt/proc/get_beacons(mob/user)
+	var/golem_mode = FALSE
+	var/list/L = list()
+	// The shoes send you home, to where you belong
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		if(H.dna && istype(H.dna.species, /datum/species/golem))
+			golem_mode = TRUE
+
+
+	for(var/obj/item/device/radio/beacon/B in world)
+		var/turf/T = get_turf(B)
+		if(golem_mode)
+			if(istype(T.loc, /area/ruin/powered/golem_ship))
+				L += B
+		else if(T.z == ZLEVEL_STATION)
+			L += B
+
+	// If no beacons found for golems, home in on dat gold statue.
+	if(!L.len && golem_mode)
+		for(var/obj/structure/statue/gold/rd/S in world)
+			var/turf/T = get_turf(S)
+			if(istype(T.loc, /area/ruin/powered/golem_ship))
+				L += S
+
+	return L
+
+/obj/item/device/wormhole_lifebelt/proc/activate(mob/user)
 	if(!turf_check(user))
 		return
 
-	var/list/L = list()
-	for(var/obj/item/device/radio/beacon/B in world)
-		var/turf/T = get_turf(B)
-		if(T.z == ZLEVEL_STATION)
-			L += B
-	if(!L.len)
+	var/list/beacons = get_beacons(user)
+
+	if(!beacons.len)
 		user << "<span class='notice'>The [src.name] found no beacons in the world to anchor a wormhole to.</span>"
 		return
-	var/chosen_beacon = pick(L)
-	var/obj/effect/portal/wormhole/jaunt_tunnel/J = new /obj/effect/portal/wormhole/jaunt_tunnel(get_turf(src), chosen_beacon, lifespan=100)
+	var/chosen_beacon = pick(beacons)
+	var/obj/effect/portal/wormhole/jaunt_tunnel/J = new(get_turf(src), chosen_beacon, lifespan=100)
 	J.target = chosen_beacon
 	try_move_adjacent(J)
+	visible_message("<span class='warning'>A [J] appears!</span>", "<span class='notice'>You hear sparks.</span>")
 	playsound(src,'sound/effects/sparks4.ogg',50,1)
 	qdel(src)
 
-/obj/item/device/wormhole_jaunter/emp_act(power)
+/obj/item/device/wormhole_lifebelt/emp_act(power)
 	var/triggered = FALSE
 
 	if(usr.get_item_by_slot(slot_belt) == src)
@@ -537,24 +616,29 @@
 			triggered = TRUE
 
 	if(triggered)
-		usr.visible_message("<span class='warning'>The [src] overloads and activates!</span>")
+		usr.visible_message("<span class='warning'>[src] overloads and activates!</span>")
 		feedback_add_details("jaunter","E") // EMP accidental activation
 		activate(usr)
 
-/obj/item/device/wormhole_jaunter/proc/chasm_react(mob/user)
+/obj/item/device/wormhole_lifebelt/chasm_react(mob/user)
 	if(user.get_item_by_slot(slot_belt) == src)
-		user << "Your [src] activates, saving you from the chasm!</span>"
+		. = TRUE
+		user << "[src] activates, saving you from the chasm!</span>"
 		feedback_add_details("jaunter","C") // chasm automatic activation
 		activate(user)
 	else
-		user << "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>"
+		user << "[src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>"
+		. = FALSE
 
 
 /obj/effect/portal/wormhole/jaunt_tunnel
-	name = "jaunt tunnel"
+	name = "lifebelt tunnel"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "bhole3"
-	desc = "A stable hole in the universe made by a wormhole jaunter. Turbulent doesn't even begin to describe how rough passage through one of these is, but at least it will always get you somewhere near a beacon."
+	desc = "A stable hole in the universe made by a wormhole lifebelt. \
+		Turbulent doesn't even begin to describe how rough passage through \
+		one of these is, but at least it will always get you somewhere near a \
+		beacon."
 
 /obj/effect/portal/wormhole/jaunt_tunnel/teleport(atom/movable/M)
 	if(istype(M, /obj/effect))
@@ -562,6 +646,7 @@
 	if(istype(M, /atom/movable))
 		if(do_teleport(M, target, 6))
 			// KERPLUNK
+			M.visible_message("<span class='warning'>[M] appears from nowhere!</span>", null, "<span class='warning'>There is a loud ker-plunk noise!</span>")
 			playsound(M,'sound/weapons/resonator_blast.ogg',50,1)
 			if(iscarbon(M))
 				var/mob/living/carbon/L = M
@@ -1120,44 +1205,20 @@
 
 /obj/machinery/mineral/equipment_vendor/golem
 	name = "golem ship equipment vendor"
-	desc = "A modified mining equipment vendor. It seems a few selections were replaced."
-	prize_list = list(
-		new /datum/data/mining_equipment("Stimpack",				/obj/item/weapon/reagent_containers/hypospray/medipen/stimpack,	    	50),
-		new /datum/data/mining_equipment("Stimpack Bundle",			/obj/item/weapon/storage/box/medipens/utility,	 				  		200),
-		new /datum/data/mining_equipment("Whiskey",             	/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,    		100),
-		new /datum/data/mining_equipment("Absinthe",            	/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/premium,100),
-		new /datum/data/mining_equipment("Soap",                	/obj/item/weapon/soap/nanotrasen, 						          		200),
-		new /datum/data/mining_equipment("Science Goggles",       	/obj/item/clothing/glasses/science, 				                   	250),
-		new /datum/data/mining_equipment("Laser Pointer",       	/obj/item/device/laser_pointer, 				                   		300),
-		new /datum/data/mining_equipment("Alien Toy",           	/obj/item/clothing/mask/facehugger/toy, 		                   		300),
-		new /datum/data/mining_equipment("Monkey Cube",				/obj/item/weapon/reagent_containers/food/snacks/monkeycube,        		300),
-		new /datum/data/mining_equipment("Toolbelt",				/obj/item/weapon/storage/belt/utility,	    							350),
-		new /datum/data/mining_equipment("Stabilizing Serum",		/obj/item/weapon/hivelordstabilizer,		                     		400),
-		new /datum/data/mining_equipment("Shelter Capsule",			/obj/item/weapon/survivalcapsule,			                     		400),
-		new /datum/data/mining_equipment("GAR scanners",			/obj/item/clothing/glasses/meson/gar,					  		   		500),
-		new /datum/data/mining_equipment("Sulphuric Acid",			/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,        		500),
-		new /datum/data/mining_equipment("Brute First-Aid Kit",		/obj/item/weapon/storage/firstaid/brute,						   		600),
-		new /datum/data/mining_equipment("Advanced Scanner",		/obj/item/device/t_scanner/adv_mining_scanner,                     		800),
-		new /datum/data/mining_equipment("Kinetic Accelerator", 	/obj/item/weapon/gun/energy/kinetic_accelerator,               	   		750),
-		new /datum/data/mining_equipment("Resonator",           	/obj/item/weapon/resonator,                                    	   		800),
-		new /datum/data/mining_equipment("Lazarus Injector",    	/obj/item/weapon/lazarus_injector,                                		1000),
-		new /datum/data/mining_equipment("Modification Kit",   	 	/obj/item/modkit,                                	                	1000),
-		new /datum/data/mining_equipment("Silver Pickaxe",			/obj/item/weapon/pickaxe/silver,				                  		1000),
-		new /datum/data/mining_equipment("Grey Slime Extract",		/obj/item/slime_extract/grey,				       		           		1000),
-		new /datum/data/mining_equipment("Diamond Pickaxe",			/obj/item/weapon/pickaxe/diamond,				                  		2000),
-		new /datum/data/mining_equipment("Super Resonator",     	/obj/item/weapon/resonator/upgraded,                              		2500),
-		new /datum/data/mining_equipment("Super Accelerator",		/obj/item/weapon/gun/energy/kinetic_accelerator/super,			  		3000),
-		new /datum/data/mining_equipment("Point Transfer Card", 	/obj/item/weapon/card/mining_point_card,               			   		500),
-		new /datum/data/mining_equipment("Mining Drone",        	/mob/living/simple_animal/hostile/mining_drone,                   		800),
-		new /datum/data/mining_equipment("Drone Melee Upgrade", 	/obj/item/device/mine_bot_ugprade,      			   			   		400),
-		new /datum/data/mining_equipment("Drone Health Upgrade",	/obj/item/device/mine_bot_ugprade/health,      			   	       		400),
-		new /datum/data/mining_equipment("Drone Ranged Upgrade",	/obj/item/device/mine_bot_ugprade/cooldown,      			   	   		600),
-		new /datum/data/mining_equipment("Drone AI Upgrade",    	/obj/item/slimepotion/sentience/mining,      			   	      		1000),
-		new /datum/data/mining_equipment("The Liberator's Legacy",  /obj/item/weapon/storage/box/rndboards,      			      			2000),
-		)
 
 /obj/machinery/mineral/equipment_vendor/golem/New()
 	..()
+	desc += "\nIt seems a few selections have been added."
+	prize_list += list(
+		new /datum/data/mining_equipment("Science Goggles",       	/obj/item/clothing/glasses/science, 				                   	250),
+		new /datum/data/mining_equipment("Monkey Cube",				/obj/item/weapon/reagent_containers/food/snacks/monkeycube,        		300),
+		new /datum/data/mining_equipment("Toolbelt",				/obj/item/weapon/storage/belt/utility,	    							350),
+		new /datum/data/mining_equipment("Sulphuric Acid",			/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,        		500),
+		new /datum/data/mining_equipment("Brute First-Aid Kit",		/obj/item/weapon/storage/firstaid/brute,						   		600),
+		new /datum/data/mining_equipment("Grey Slime Extract",		/obj/item/slime_extract/grey,				       		           		1000),
+		new /datum/data/mining_equipment("The Liberator's Legacy",  /obj/item/weapon/storage/box/rndboards,      			      			2000),
+		)
+
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/mining_equipment_vendor/golem(null)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
@@ -1165,3 +1226,4 @@
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	RefreshParts()
+

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -572,14 +572,18 @@
 		var/mob/living/simple_animal/SA = AM
 		if(SA.flying)
 			return
-	if(istype(AM, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = AM
-		if(istype(H.belt, /obj/item/device/wormhole_jaunter))
-			var/obj/item/device/wormhole_jaunter/J = H.belt
-			// To freak out any bystanders
-			visible_message("[H] falls into [src]!")
-			J.chasm_react(H)
-			return
+	if(istype(AM, /mob/living))
+		var/mob/living/M = AM
+		for(var/atom/movable/thing in M)
+			if(!istype(thing, /obj/item))
+				continue
+			var/obj/item/I = thing
+			// Is anything inside you going to save you?
+			var/outcome = I.chasm_react(M)
+			if(outcome)
+				// To freak out any bystanders
+				visible_message("[M] falls into [src]!")
+				return
 	drop(AM)
 
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -574,7 +574,7 @@
 			return
 	if(istype(AM, /mob/living))
 		var/mob/living/M = AM
-		for(var/atom/movable/thing in M)
+		for(var/atom/movable/thing in M.GetAllContents())
 			if(!istype(thing, /obj/item))
 				continue
 			var/obj/item/I = thing

--- a/code/modules/ruins/ruin_areas.dm
+++ b/code/modules/ruins/ruin_areas.dm
@@ -17,16 +17,17 @@
 
 
 
+
 //Areas
 
 /area/ruin/unpowered/no_grav/way_home
 	name = "\improper Salvation"
 	icon_state = "away"
 
-
-
 /area/ruin/powered/snow_biodome
 
+/area/ruin/powered/golem_ship
+	name = "Free Golem Ship"
 
 // Ruins of "onehalf" ship
 /area/ruin/onehalf/hallway


### PR DESCRIPTION
- The Jaunter has been renamed to Wormhole Lifebelt.
- Wormhole Lifebelt has an advanced version that triggers when the user is in crit.
- Golems are immune to most of the negative effects of wormhole travel.
- Golems target the Free Golem ship instead of on station beacons.
- Falling into chasms now searches the entire contents of the person (currently only used for lifebelt, but would allow for anti-chasm implants).
- The golem equipment vendor is regular vendor PLUS bonus items, due to jaunters no longer being tickets to the station, and KAs being modifiable.